### PR TITLE
Update links in Three.js examples

### DIFF
--- a/html/en/reference/plot3d/threejs.html
+++ b/html/en/reference/plot3d/threejs.html
@@ -129,8 +129,8 @@ lines thicker than available using <code class="docutils literal"><span class="p
 
 <body>
 
-<script src=&quot;/Users/Masson/Downloads/GitHub/sage/local/share/threejs/three.min.js&quot;></script>
-<script src=&quot;/Users/Masson/Downloads/GitHub/sage/local/share/threejs/OrbitControls.js&quot;></script>
+<script src=&quot;https://cdn.rawgit.com/mrdoob/three.js/r80/build/three.min.js&quot;></script>
+<script src=&quot;https://cdn.rawgit.com/mrdoob/three.js/r80/examples/js/controls/OrbitControls.js&quot;></script>
                 
 <script>
 
@@ -401,8 +401,8 @@ lines thicker than available using <code class="docutils literal"><span class="p
 
 <body>
 
-<script src=&quot;/Users/Masson/Downloads/GitHub/sage/local/share/threejs/three.min.js&quot;></script>
-<script src=&quot;/Users/Masson/Downloads/GitHub/sage/local/share/threejs/OrbitControls.js&quot;></script>
+<script src=&quot;https://cdn.rawgit.com/mrdoob/three.js/r80/build/three.min.js&quot;></script>
+<script src=&quot;https://cdn.rawgit.com/mrdoob/three.js/r80/examples/js/controls/OrbitControls.js&quot;></script>
                 
 <script>
 


### PR DESCRIPTION
The links in these examples are incorrectly pointing to files on my local computer and should be updated to point to the CDN.

I have submitted the correction to Trac as expected: https://trac.sagemath.org/ticket/23532. It's a simple eyeball review if you have the time.

While I know you don't normally merge pull requests on GitHub, I would appreciate if you would consider this one. Otherwise these two examples will be broken until the next version of Sage.

Thanks!