### PR TITLE
[doc] broken link in en/installation/linux.html

### DIFF
--- a/html/en/installation/linux.html
+++ b/html/en/installation/linux.html
@@ -227,7 +227,7 @@ version of SageMath is only available on a newer version of the
 distribution, consider upgrading your distribution.</p>
 <p>Gentoo users might want to give a try to
 <a class="reference external" href="https://github.com/cschwan/sage-on-gentoo">sage-on-gentoo</a>.</p>
-<p>The  <span class="math notranslate nohighlight">\(GitHub wiki page Distribution &lt;https://github.com/sagemath/sage/wiki/Distribution&gt;\)</span> collects information
+<p>The <a class="reference external" href="https://github.com/sagemath/sage/wiki/Distribution">GitHub wiki page: Distribution</a> collects information
 regarding packaging and distribution of SageMath.</p>
 </section>
 


### PR DESCRIPTION
Assuming this was meant to be a hyperlink, I've edited it to make it look that way. Appears weird on the HTML documentation page.